### PR TITLE
Use CApiFFI instead of ForeignFunctionInterface

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,65 +2,34 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay"
+        ]
       },
       "locked": {
-        "lastModified": 1670900067,
-        "narHash": "sha256-VXVa+KBfukhmWizaiGiHRVX/fuk66P8dgSFfkVN4/MY=",
+        "lastModified": 1703439018,
+        "narHash": "sha256-VT+06ft/x3eMZ1MJxWzQP3zXFGcrxGo5VR2rB7t88hs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59b31b41a589c0a65e4a1f86b0e5eac68081468b",
+        "rev": "afdcd41180e3dfe4dac46b5ee396e3b12ccc967a",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
         "type": "github"
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
+      "inputs": {
+        "systems": "systems"
       },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -71,16 +40,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671293269,
-        "narHash": "sha256-O5x+xAbv/aj7sUJ3Utz7sro0xpqAhx83JA+Wp2CHWsg=",
+        "lastModified": 1704018918,
+        "narHash": "sha256-erjg/HrpC9liEfm7oLqb8GXCqsxaFwIIPqCsknW5aFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da36c54602a7dd9ff707c89a48df2405a7b0d703",
+        "rev": "2c9c58e98243930f8cb70387934daa4bc8b00373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -88,32 +57,22 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "crane",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "crane",
-          "nixpkgs"
-        ]
-      },
+    "systems": {
       "locked": {
-        "lastModified": 1670034122,
-        "narHash": "sha256-EqmuOKucPWtMvCZtHraHr3Q3bgVszq1x2PoZtQkUuEk=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "a0d5773275ecd4f141d792d3a0376277c0fc0b65",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A flake for building lrzhs, a set of Haskell bindings for librustzcash";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/release-22.11;
+    nixpkgs.url = github:NixOS/nixpkgs/release-23.05;
     flake-utils.url = "github:numtide/flake-utils";
     crane = {
       inputs.nixpkgs.follows = "nixpkgs";

--- a/lrzhs.cabal
+++ b/lrzhs.cabal
@@ -1,4 +1,4 @@
-cabal-version:      2.4
+cabal-version:      3.0
 name:               lrzhs
 version:            0.1.0.0
 
@@ -23,7 +23,7 @@ extra-source-files: CHANGELOG.md, rust/target/Headers/lrzhs_ffi.h
 
 library
     build-depends:    
-      base            ^>= 4.15.1.0,
+      base             >= 4.16.4.0,
       text             >= 1.2.5 && < 1.3
     hs-source-dirs:   src
 

--- a/lrzhs.cabal
+++ b/lrzhs.cabal
@@ -19,7 +19,7 @@ maintainer:         kris@nutty.land
 -- A copyright notice.
 -- copyright:
 -- category:
-extra-source-files: CHANGELOG.md
+extra-source-files: CHANGELOG.md, rust/target/Headers/lrzhs_ffi.h
 
 library
     build-depends:    
@@ -45,3 +45,5 @@ library
       Lrzhs.Ffi
     extra-libraries:
       lrzhs_ffi
+    include-dirs: rust/target/Headers
+    includes: rust/target/Headers/lrzhs_ffi.h

--- a/rust/target/Headers/lrzhs_ffi.h
+++ b/rust/target/Headers/lrzhs_ffi.h
@@ -1,0 +1,941 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * A struct that contains an account identifier along with a pointer to the binary encoding
+ * of an associated key.
+ *
+ * # Safety
+ *
+ * - `encoding` must be non-null and must point to an array of `encoding_len` bytes.
+ */
+typedef struct {
+  uint32_t account_id;
+  uint8_t *encoding;
+  uintptr_t encoding_len;
+} FFIBinaryKey;
+
+/**
+ * A struct that contains an account identifier along with a pointer to the string encoding
+ * of an associated key.
+ *
+ * # Safety
+ *
+ * - `encoding` must be non-null and must point to a null-terminated UTF-8 string.
+ */
+typedef struct {
+  uint32_t account_id;
+  char *encoding;
+} FFIEncodedKey;
+
+/**
+ * A struct that contains a pointer to, and length information for, a heap-allocated
+ * slice of [`FFIEncodedKey`] values.
+ *
+ * # Safety
+ *
+ * - `ptr` must be non-null and must be valid for reads for `len * mem::size_of::<FFIEncodedKey>()`
+ *   many bytes, and it must be properly aligned. This means in particular:
+ *   - The entire memory range pointed to by `ptr` must be contained within a single allocated
+ *     object. Slices can never span across multiple allocated objects.
+ *   - `ptr` must be non-null and aligned even for zero-length slices.
+ *   - `ptr` must point to `len` consecutive properly initialized values of type
+ *     [`FFIEncodedKey`].
+ * - The total size `len * mem::size_of::<FFIEncodedKey>()` of the slice pointed to
+ *   by `ptr` must be no larger than isize::MAX. See the safety documentation of pointer::offset.
+ * - See the safety documentation of [`FFIEncodedKey`]
+ */
+typedef struct {
+  FFIEncodedKey *ptr;
+  uintptr_t len;
+} FFIEncodedKeys;
+
+int32_t lrzhs_branch_id_for_height(int32_t height, uint32_t network_id);
+
+/**
+ * Clears the record of the last error message.
+ */
+void lrzhs_clear_last_error(void);
+
+/**
+ * Adds the next available account-level spend authority, given the current set of [ZIP 316]
+ * account identifiers known, to the wallet database.
+ *
+ * Returns the newly created [ZIP 316] account identifier, along with the binary encoding of the
+ * [`UnifiedSpendingKey`] for the newly created account.  The caller should manage the memory of
+ * (and store) the returned spending keys in a secure fashion.
+ *
+ * If `seed` was imported from a backup and this method is being used to restore a
+ * previous wallet state, you should use this method to add all of the desired
+ * accounts before scanning the chain from the seed's birthday height.
+ *
+ * By convention, wallets should only allow a new account to be generated after funds
+ * have been received by the currently available account (in order to enable
+ * automated account recovery).
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `seed` must be non-null and valid for reads for `seed_len` bytes, and it must have an
+ *   alignment of `1`.
+ * - The memory referenced by `seed` must not be mutated for the duration of the function call.
+ * - The total size `seed_len` must be no larger than `isize::MAX`. See the safety documentation
+ *   of pointer::offset.
+ * - Call [`lrzhs_free_binary_key`] to free the memory associated with the returned pointer when
+ *   you are finished using it.
+ *
+ * [ZIP 316]: https://zips.z.cash/zip-0316
+ */
+FFIBinaryKey *lrzhs_create_account(const uint8_t *db_data,
+                                   uintptr_t db_data_len,
+                                   const uint8_t *seed,
+                                   uintptr_t seed_len,
+                                   uint32_t network_id);
+
+/**
+ * Creates a transaction paying the specified address from the given account.
+ *
+ * Returns the row index of the newly-created transaction in the `transactions` table
+ * within the data database. The caller can read the raw transaction bytes from the `raw`
+ * column in order to broadcast the transaction to the network.
+ *
+ * Do not call this multiple times in parallel, or you will generate transactions that
+ * double-spend the same notes.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `usk_ptr` must be non-null and must point to an array of `usk_len` bytes containing a unified
+ *   spending key encoded as returned from the `lrzhs_create_account` or
+ *   `lrzhs_derive_spending_key` functions.
+ * - The memory referenced by `usk_ptr` must not be mutated for the duration of the function call.
+ * - The total size `usk_len` must be no larger than `isize::MAX`. See the safety documentation
+ *   of pointer::offset.
+ * - `to` must be non-null and must point to a null-terminated UTF-8 string.
+ * - `memo` must either be null (indicating an empty memo or a transparent recipient) or point to a
+ *    512-byte array.
+ * - `spend_params` must be non-null and valid for reads for `spend_params_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be the Sapling spend proving parameters.
+ * - The memory referenced by `spend_params` must not be mutated for the duration of the function call.
+ * - The total size `spend_params_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `output_params` must be non-null and valid for reads for `output_params_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be the Sapling output proving parameters.
+ * - The memory referenced by `output_params` must not be mutated for the duration of the function call.
+ * - The total size `output_params_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int64_t lrzhs_create_to_address(const uint8_t *db_data,
+                                uintptr_t db_data_len,
+                                const uint8_t *usk_ptr,
+                                uintptr_t usk_len,
+                                const char *to,
+                                int64_t value,
+                                const uint8_t *memo,
+                                const uint8_t *spend_params,
+                                uintptr_t spend_params_len,
+                                const uint8_t *output_params,
+                                uintptr_t output_params_len,
+                                uint32_t network_id,
+                                uint32_t min_confirmations,
+                                bool use_zip317_fees);
+
+/**
+ * Decrypts whatever parts of the specified transaction it can and stores them in db_data.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `tx` must be non-null and valid for reads for `tx_len` bytes, and it must have an
+ *   alignment of `1`.
+ * - The memory referenced by `tx` must not be mutated for the duration of the function call.
+ * - The total size `tx_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int32_t lrzhs_decrypt_and_store_transaction(const uint8_t *db_data,
+                                            uintptr_t db_data_len,
+                                            const uint8_t *tx,
+                                            uintptr_t tx_len,
+                                            uint32_t _mined_height,
+                                            uint32_t network_id);
+
+/**
+ * Derives and returns a unified spending key from the given seed for the given account ID.
+ *
+ * Returns the binary encoding of the spending key. The caller should manage the memory of (and
+ * store, if necessary) the returned spending key in a secure fashion.
+ *
+ * # Safety
+ *
+ * - `seed` must be non-null and valid for reads for `seed_len` bytes, and it must have an
+ *   alignment of `1`.
+ * - The memory referenced by `seed` must not be mutated for the duration of the function call.
+ * - The total size `seed_len` must be no larger than `isize::MAX`. See the safety documentation
+ *   of pointer::offset.
+ * - Call `lrzhs_free_binary_key` to free the memory associated with the returned pointer when
+ *   you are finished using it.
+ */
+FFIBinaryKey *lrzhs_derive_spending_key(const uint8_t *seed,
+                                        uintptr_t seed_len,
+                                        int32_t account,
+                                        uint32_t network_id);
+
+/**
+ * Copies the last error message into the provided allocated buffer.
+ *
+ * # Safety
+ *
+ * - `buf` must be non-null and valid for reads for `length` bytes, and it must have an alignment
+ *   of `1`.
+ * - The memory referenced by `buf` must not be mutated for the duration of the function call.
+ * - The total size `length` must be no larger than `isize::MAX`. See the safety documentation of
+ *   pointer::offset.
+ */
+int32_t lrzhs_error_message_utf8(char *buf, int32_t length);
+
+/**
+ * Frees a FFIBinaryKey value
+ *
+ * # Safety
+ *
+ * - `ptr` must be non-null and must point to a struct having the layout of [`FFIBinaryKey`].
+ *   See the safety documentation of [`FFIBinaryKey`].
+ */
+void lrzhs_free_binary_key(FFIBinaryKey *ptr);
+
+/**
+ * Frees an array of FFIEncodedKeys values as allocated by `lrzhs_derive_unified_viewing_keys_from_seed`
+ *
+ * # Safety
+ *
+ * - `ptr` must be non-null and must point to a struct having the layout of [`FFIEncodedKeys`].
+ *   See the safety documentation of [`FFIEncodedKeys`].
+ */
+void lrzhs_free_keys(FFIEncodedKeys *ptr);
+
+/**
+ * Frees a list of typecodes previously obtained from the FFI.
+ *
+ * # Safety
+ *
+ * - `data` and `len` must have been obtained from
+ *   [`lrzhs_get_typecodes_for_unified_address_receivers`].
+ */
+void lrzhs_free_typecodes(uint32_t *data, uintptr_t len);
+
+/**
+ * Returns the network type and address kind for the given address string,
+ * if the address is a valid Zcash address.
+ *
+ * Address kind codes are as follows:
+ * * p2pkh: 0
+ * * p2sh: 1
+ * * sapling: 2
+ * * unified: 3
+ *
+ * # Safety
+ *
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+bool lrzhs_get_address_metadata(const char *address,
+                                uint32_t *network_id_ret,
+                                uint32_t *addr_kind_ret);
+
+/**
+ * Returns the balance for the specified account, including all unspent notes that we know about.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int64_t lrzhs_get_balance(const uint8_t *db_data,
+                          uintptr_t db_data_len,
+                          int32_t account,
+                          uint32_t network_id);
+
+/**
+ * Returns the most-recently-generated unified payment address for the specified account.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+char *lrzhs_get_current_address(const uint8_t *db_data,
+                                uintptr_t db_data_len,
+                                int32_t account,
+                                uint32_t network_id);
+
+/**
+ * Returns the most recent block height to which it is possible to reset the state
+ * of the data database.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int32_t lrzhs_get_nearest_rewind_height(const uint8_t *db_data,
+                                        uintptr_t db_data_len,
+                                        int32_t height,
+                                        uint32_t network_id);
+
+/**
+ * Returns a newly-generated unified payment address for the specified account, with the next
+ * available diversifier.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+char *lrzhs_get_next_available_address(const uint8_t *db_data,
+                                       uintptr_t db_data_len,
+                                       int32_t account,
+                                       uint32_t network_id);
+
+/**
+ * Returns the memo for a received note by copying the corresponding bytes to the received
+ * pointer in `memo_bytes_ret`.
+ *
+ * The note is identified by its row index in the `received_notes` table within the data
+ * database.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `memo_bytes_ret` must be non-null and must point to an allocated 512-byte region of memory.
+ */
+bool lrzhs_get_received_memo(const uint8_t *db_data,
+                             uintptr_t db_data_len,
+                             int64_t id_note,
+                             uint8_t *memo_bytes_ret,
+                             uint32_t network_id);
+
+/**
+ * Returns the memo for a received note, if it is known and a valid UTF-8 string.
+ *
+ * The note is identified by its row index in the `received_notes` table within the data
+ * database.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+char *lrzhs_get_received_memo_as_utf8(const uint8_t *db_data,
+                                      uintptr_t db_data_len,
+                                      int64_t id_note,
+                                      uint32_t network_id);
+
+/**
+ * Returns the Sapling receiver within the given Unified Address, if any.
+ *
+ * # Safety
+ *
+ * - `ua` must be non-null and must point to a null-terminated UTF-8 string.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+char *lrzhs_get_sapling_receiver_for_unified_address(const char *ua);
+
+/**
+ * Returns the memo for a sent note, by copying the corresponding bytes to the received
+ * pointer in `memo_bytes_ret`.
+ *
+ * The note is identified by its row index in the `sent_notes` table within the data
+ * database.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `memo_bytes_ret` must be non-null and must point to an allocated 512-byte region of memory.
+ */
+bool lrzhs_get_sent_memo(const uint8_t *db_data,
+                         uintptr_t db_data_len,
+                         int64_t id_note,
+                         uint8_t *memo_bytes_ret,
+                         uint32_t network_id);
+
+/**
+ * Returns the memo for a sent note, if it is known and a valid UTF-8 string.
+ *
+ * The note is identified by its row index in the `sent_notes` table within the data
+ * database.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+char *lrzhs_get_sent_memo_as_utf8(const uint8_t *db_data,
+                                  uintptr_t db_data_len,
+                                  int64_t id_note,
+                                  uint32_t network_id);
+
+/**
+ * Returns the balance for `address`, including all UTXOs that we know about.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+int64_t lrzhs_get_total_transparent_balance(const uint8_t *db_data,
+                                            uintptr_t db_data_len,
+                                            const char *address,
+                                            uint32_t network_id);
+
+/**
+ * Returns the balance for `account`, including all UTXOs that we know about.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+int64_t lrzhs_get_total_transparent_balance_for_account(const uint8_t *db_data,
+                                                        uintptr_t db_data_len,
+                                                        uint32_t network_id,
+                                                        int32_t account);
+
+/**
+ * Returns the transparent receiver within the given Unified Address, if any.
+ *
+ * # Safety
+ *
+ * - `ua` must be non-null and must point to a null-terminated UTF-8 string.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+char *lrzhs_get_transparent_receiver_for_unified_address(const char *ua);
+
+/**
+ * Extracts the typecodes of the receivers within the given Unified Address.
+ *
+ * Returns a pointer to a slice of typecodes. `len_ret` is set to the length of the
+ * slice.
+ *
+ * See the following sections of ZIP 316 for details on how to interpret typecodes:
+ * - [List of known typecodes](https://zips.z.cash/zip-0316#encoding-of-unified-addresses)
+ * - [Adding new types](https://zips.z.cash/zip-0316#adding-new-types)
+ * - [Metadata Items](https://zips.z.cash/zip-0316#metadata-items)
+ *
+ * # Safety
+ *
+ * - `ua` must be non-null and must point to a null-terminated UTF-8 string containing an
+ *   encoded Unified Address.
+ * - Call [`lrzhs_free_typecodes`] to free the memory associated with the returned
+ *   pointer when done using it.
+ */
+uint32_t *lrzhs_get_typecodes_for_unified_address_receivers(const char *ua, uintptr_t *len_ret);
+
+/**
+ * Returns the verified balance for the account, which ignores notes that have been
+ * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int64_t lrzhs_get_verified_balance(const uint8_t *db_data,
+                                   uintptr_t db_data_len,
+                                   int32_t account,
+                                   uint32_t network_id,
+                                   uint32_t min_confirmations);
+
+/**
+ * Returns the verified transparent balance for `address`, which ignores utxos that have been
+ * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+int64_t lrzhs_get_verified_transparent_balance(const uint8_t *db_data,
+                                               uintptr_t db_data_len,
+                                               const char *address,
+                                               uint32_t network_id,
+                                               uint32_t min_confirmations);
+
+/**
+ * Returns the verified transparent balance for `account`, which ignores utxos that have been
+ * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+int64_t lrzhs_get_verified_transparent_balance_for_account(const uint8_t *db_data,
+                                                           uintptr_t db_data_len,
+                                                           uint32_t network_id,
+                                                           int32_t account,
+                                                           uint32_t min_confirmations);
+
+/**
+ * Initialises the data database with the given set of unified full viewing keys. This
+ * should only be used in special cases for implementing wallet recovery; prefer
+ * `lrzhs_create_account` for normal account creation purposes.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `ufvks` must be non-null and valid for reads for `ufvks_len * sizeof(FFIEncodedKey)` bytes.
+ *   It must point to an array of `FFIEncodedKey` values.
+ * - The memory referenced by `ufvks` must not be mutated for the duration of the function call.
+ * - The total size `ufvks_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+bool lrzhs_init_accounts_table_with_keys(const uint8_t *db_data,
+                                         uintptr_t db_data_len,
+                                         FFIEncodedKey *ufvks_ptr,
+                                         uintptr_t ufvks_len,
+                                         uint32_t network_id);
+
+/**
+ * Initialises the data database with the given block metadata.
+ *
+ * This enables a newly-created database to be immediately-usable, without needing to
+ * synchronise historic blocks.
+ *
+ * The string represented by `sapling_tree_hex` should contain the encoded byte representation
+ * of a Sapling commitment tree.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `hash_hex` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `hash_hex` must not be mutated for the duration of the function call.
+ * - `sapling_tree_hex` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `sapling_tree_hex` must not be mutated for the duration of the
+ *   function call.
+ */
+int32_t lrzhs_init_blocks_table(const uint8_t *db_data,
+                                uintptr_t db_data_len,
+                                int32_t height,
+                                const char *hash_hex,
+                                uint32_t time,
+                                const char *sapling_tree_hex,
+                                uint32_t network_id);
+
+/**
+ * Sets up the internal structure of the data database.  The value for `seed` may be provided as a
+ * null pointer if the caller wishes to attempt migrations without providing the wallet's seed
+ * value.
+ *
+ * Returns 0 if successful, 1 if the seed must be provided in order to execute the requested
+ * migrations, or -1 otherwise.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `seed` must be non-null and valid for reads for `seed_len` bytes, and it must have an
+ *   alignment of `1`.
+ * - The memory referenced by `seed` must not be mutated for the duration of the function call.
+ * - The total size `seed_len` must be no larger than `isize::MAX`. See the safety documentation
+ *   of pointer::offset.
+ */
+int32_t lrzhs_init_data_database(const uint8_t *db_data,
+                                 uintptr_t db_data_len,
+                                 const uint8_t *seed,
+                                 uintptr_t seed_len,
+                                 uint32_t network_id);
+
+/**
+ * Returns true when the provided key decodes to a valid Sapling extended spending key for the
+ * specified network, false in any other case.
+ *
+ * # Safety
+ *
+ * - `extsk` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `extsk` must not be mutated for the duration of the function call.
+ */
+bool lrzhs_is_valid_sapling_extended_spending_key(const char *extsk, uint32_t network_id);
+
+/**
+ * Returns true when the provided address decodes to a valid Sapling payment address for the
+ * specified network, false in any other case.
+ *
+ * # Safety
+ *
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+bool lrzhs_is_valid_shielded_address(const char *address, uint32_t network_id);
+
+/**
+ * Returns true when the address is a valid transparent payment address for the specified network,
+ * false in any other case.
+ *
+ * # Safety
+ *
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the function call.
+ */
+bool lrzhs_is_valid_transparent_address(const char *address, uint32_t network_id);
+
+/**
+ * Returns true when the provided key decodes to a valid unified address for the
+ * specified network, false in any other case.
+ *
+ * # Safety
+ *
+ * - `address` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `address` must not be mutated for the duration of the
+ *   function call.
+ */
+bool lrzhs_is_valid_unified_address(const char *address, uint32_t network_id);
+
+/**
+ * Returns true when the provided key decodes to a valid unified full viewing key for the
+ * specified network, false in any other case.
+ *
+ * # Safety
+ *
+ * - `ufvk` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `ufvk` must not be mutated for the duration of the
+ *   function call.
+ */
+bool lrzhs_is_valid_unified_full_viewing_key(const char *ufvk, uint32_t network_id);
+
+/**
+ * Returns true when the provided key decodes to a valid Sapling extended full viewing key for the
+ * specified network, false in any other case.
+ *
+ * # Safety
+ *
+ * - `key` must be non-null and must point to a null-terminated UTF-8 string.
+ * - The memory referenced by `key` must not be mutated for the duration of the function call.
+ */
+bool lrzhs_is_valid_viewing_key(const char *key, uint32_t network_id);
+
+/**
+ * Returns the length of the last error message to be logged.
+ */
+int32_t lrzhs_last_error_length(void);
+
+/**
+ * Returns a list of the transparent receivers for the diversified unified addresses that have
+ * been allocated for the provided account.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - Call [`lrzhs_free_keys`] to free the memory associated with the returned pointer
+ *   when done using it.
+ */
+FFIEncodedKeys *lrzhs_list_transparent_receivers(const uint8_t *db_data,
+                                                 uintptr_t db_data_len,
+                                                 int32_t account_id,
+                                                 uint32_t network_id);
+
+/**
+ * Inserts a UTXO into the wallet database.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `txid_bytes` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`.
+ * - The memory referenced by `txid_bytes_len` must not be mutated for the duration of the function call.
+ * - The total size `txid_bytes_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `script_bytes` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`.
+ * - The memory referenced by `script_bytes_len` must not be mutated for the duration of the function call.
+ * - The total size `script_bytes_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+bool lrzhs_put_utxo(const uint8_t *db_data,
+                    uintptr_t db_data_len,
+                    const uint8_t *txid_bytes,
+                    uintptr_t txid_bytes_len,
+                    int32_t index,
+                    const uint8_t *script_bytes,
+                    uintptr_t script_bytes_len,
+                    int64_t value,
+                    int32_t height,
+                    uint32_t network_id);
+
+/**
+ * Rewinds the data database to the given height.
+ *
+ * If the requested height is greater than or equal to the height of the last scanned
+ * block, this function does nothing.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+bool lrzhs_rewind_to_height(const uint8_t *db_data,
+                            uintptr_t db_data_len,
+                            int32_t height,
+                            uint32_t network_id);
+
+/**
+ * Scans new blocks added to the cache for any transactions received by the tracked
+ * accounts.
+ *
+ * This function pays attention only to cached blocks with heights greater than the
+ * highest scanned block in `db_data`. Cached blocks with lower heights are not verified
+ * against previously-scanned blocks. In particular, this function **assumes** that the
+ * caller is handling rollbacks.
+ *
+ * For brand-new light client databases, this function starts scanning from the Sapling
+ * activation height. This height can be fast-forwarded to a more recent block by calling
+ * [`lrzhs_init_blocks_table`] before this function.
+ *
+ * Scanned blocks are required to be height-sequential. If a block is missing from the
+ * cache, an error will be signalled.
+ *
+ * # Safety
+ *
+ * - `db_cache` must be non-null and valid for reads for `db_cache_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_cache` must not be mutated for the duration of the function call.
+ * - The total size `db_cache_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int32_t lrzhs_scan_blocks(const uint8_t *db_cache,
+                          uintptr_t db_cache_len,
+                          const uint8_t *db_data,
+                          uintptr_t db_data_len,
+                          uint32_t scan_limit,
+                          uint32_t network_id);
+
+/**
+ * Shield transparent UTXOs by sending them to an address associated with the specified Sapling
+ * spending key.
+ *
+ * # Safety
+ *
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `usk_ptr` must be non-null and must point to an array of `usk_len` bytes containing a unified
+ *   spending key encoded as returned from the `lrzhs_create_account` or
+ *   `lrzhs_derive_spending_key` functions.
+ * - The memory referenced by `usk_ptr` must not be mutated for the duration of the function call.
+ * - The total size `usk_len` must be no larger than `isize::MAX`. See the safety documentation
+ * - `memo` must either be null (indicating an empty memo) or point to a 512-byte array.
+ * - `spend_params` must be non-null and valid for reads for `spend_params_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be the Sapling spend proving parameters.
+ * - The memory referenced by `spend_params` must not be mutated for the duration of the function call.
+ * - The total size `spend_params_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `output_params` must be non-null and valid for reads for `output_params_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be the Sapling output proving parameters.
+ * - The memory referenced by `output_params` must not be mutated for the duration of the function call.
+ * - The total size `output_params_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int64_t lrzhs_shield_funds(const uint8_t *db_data,
+                           uintptr_t db_data_len,
+                           const uint8_t *usk_ptr,
+                           uintptr_t usk_len,
+                           const uint8_t *memo,
+                           const uint8_t *spend_params,
+                           uintptr_t spend_params_len,
+                           const uint8_t *output_params,
+                           uintptr_t output_params_len,
+                           uint32_t network_id,
+                           bool use_zip317_fees);
+
+/**
+ * Obtains the unified full viewing key for the given binary-encoded unified spending key
+ * and returns the resulting encoded UFVK string. `usk_ptr` should point to an array of `usk_len`
+ * bytes containing a unified spending key encoded as returned from the `lrzhs_create_account`
+ * or `lrzhs_derive_spending_key` functions.
+ *
+ * # Safety
+ *
+ * - `usk_ptr` must be non-null and must point to an array of `usk_len` bytes.
+ * - The memory referenced by `usk_ptr` must not be mutated for the duration of the function call.
+ * - The total size `usk_len` must be no larger than `isize::MAX`. See the safety documentation
+ *   of pointer::offset.
+ * - Call [`lrzhs_string_free`] to free the memory associated with the returned pointer
+ *   when you are done using it.
+ */
+char *lrzhs_spending_key_to_full_viewing_key(const uint8_t *usk_ptr,
+                                             uintptr_t usk_len,
+                                             uint32_t network_id);
+
+/**
+ * Frees strings returned by other lrzhs functions.
+ *
+ * # Safety
+ *
+ * - `s` should be a non-null pointer returned as a string by another lrzhs function.
+ */
+void lrzhs_string_free(char *s);
+
+/**
+ * Checks that the scanned blocks in the data database, when combined with the recent
+ * `CompactBlock`s in the cache database, form a valid chain.
+ *
+ * This function is built on the core assumption that the information provided in the
+ * cache database is more likely to be accurate than the previously-scanned information.
+ * This follows from the design (and trust) assumption that the `lightwalletd` server
+ * provides accurate block information as of the time it was requested.
+ *
+ * Returns:
+ * - `-1` if the combined chain is valid.
+ * - `upper_bound` if the combined chain is invalid.
+ *   `upper_bound` is the height of the highest invalid block (on the assumption that the
+ *   highest block in the cache database is correct).
+ * - `0` if there was an error during validation unrelated to chain validity.
+ *
+ * This function does not mutate either of the databases.
+ *
+ * # Safety
+ *
+ * - `db_cache` must be non-null and valid for reads for `db_cache_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_cache` must not be mutated for the duration of the function call.
+ * - The total size `db_cache_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+ *   alignment of `1`. Its contents must be a string representing a valid system path in the
+ *   operating system's preferred representation.
+ * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+ * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+ *   documentation of pointer::offset.
+ */
+int32_t lrzhs_validate_combined_chain(const uint8_t *db_cache,
+                                      uintptr_t db_cache_len,
+                                      const uint8_t *db_data,
+                                      uintptr_t db_data_len,
+                                      uint32_t network_id);

--- a/src/Lrzhs/Ffi.hs
+++ b/src/Lrzhs/Ffi.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE CApiFFI #-}
 
 module Lrzhs.Ffi where
 
@@ -9,7 +9,7 @@ import Foreign.C.String (CString)
 import Foreign.Ptr ()
 import Lrzhs.Types (Network (..))
 
-foreign import ccall "lrzhs_is_valid_shielded_address" rs_is_valid_sapling_address :: CString -> CUInt -> IO CBool
+foreign import capi "lrzhs_ffi.h lrzhs_is_valid_shielded_address" rs_is_valid_sapling_address :: CString -> CUInt -> IO CBool
 
 networkId :: Network -> CUInt
 networkId = \case


### PR DESCRIPTION
This is less convenient, because `cabal repl` doesn't work with this now, so uncertain whether this change is useful.