### PR TITLE
Fix the Nix build on darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
     flake-utils.url = "github:numtide/flake-utils";
-    crane = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = github:ipetkov/crane;
-    };
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
         src = craneLib.cleanCargoSource ./rust/.;
 
         buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
-          pkgs.darwin.apple_sdk.frameworks.Security
           pkgs.libiconv
         ];
 


### PR DESCRIPTION
- The Security framework is no longer necessary (or provided).
- Crane has no `nixpkgs` input.