### PR TITLE
Add deriveOrchardAddress: Orchard-only UA from a UIVK

### DIFF
--- a/lrzhs.cabal
+++ b/lrzhs.cabal
@@ -24,6 +24,7 @@ extra-source-files: CHANGELOG.md
 library
     build-depends:
       base >= 4.15.1 && < 4.21,
+      bytestring >= 0.11 && < 0.13,
       text >= 1.2.5 && < 2.2,
     hs-source-dirs:   src
 
@@ -52,6 +53,7 @@ test-suite lrzhs-tests
     hs-source-dirs:   test
     build-depends:
       base >= 4.15.1 && < 4.21,
+      bytestring >= 0.11 && < 0.13,
       text >= 1.2.5 && < 2.2,
       lrzhs
     default-language: Haskell2010

--- a/lrzhs.cabal
+++ b/lrzhs.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               lrzhs
-version:            0.1.0.0
+version:            0.2.0.0
 
 -- A short (one-line) description of the package.
 -- synopsis:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +108,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2b_simd"
@@ -103,6 +142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +160,21 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2",
  "tinyvec",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -136,6 +201,41 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
 
 [[package]]
 name = "clap"
@@ -186,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "ffi_helpers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +382,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fpe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
+dependencies = [
+ "cbc",
+ "cipher",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +409,40 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "halo2_poseidon"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "pasta_curves",
 ]
 
 [[package]]
@@ -287,6 +464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "incrementalmerkletree"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +480,15 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -318,10 +513,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff",
+ "group",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litrs"
@@ -345,8 +569,10 @@ dependencies = [
  "anyhow",
  "cbindgen",
  "ffi_helpers",
+ "orchard",
  "zcash_address",
  "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]
@@ -368,10 +594,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "orchard"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_poseidon",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand",
+ "rand_core",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -389,6 +715,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "reddsa"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4784b85c8bfd17b36b86e664e6e504ecdb586001086ee23749e4a633bbb84832"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "group",
+ "jubjub",
+ "pasta_curves",
+ "rand_core",
 ]
 
 [[package]]
@@ -467,10 +828,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sinsemilla"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
+dependencies = [
+ "group",
+ "pasta_curves",
+ "subtle",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -493,6 +883,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -585,6 +981,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +1009,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +1029,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "winapi"
@@ -655,6 +1088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zcash_address"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +1121,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_note_encryption"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+dependencies = [
+ "chacha20",
+ "chacha20poly1305",
+ "cipher",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "zcash_protocol"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,4 +1143,32 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
+]
+
+[[package]]
+name = "zcash_spec"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded3f58b93486aa79b85acba1001f5298f27a46489859934954d262533ee2915"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zip32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64bf5186a8916f7a48f2a98ef599bf9c099e2458b36b819e393db1c0e768c4b"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "memuse",
+ "subtle",
+ "zcash_spec",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,8 @@ anyhow = "1.0"
 ffi_helpers = "0.3"
 zcash_address = "0.10"
 zcash_protocol = "0.7"
+orchard = { version = "0.14", default-features = false }
+zip32 = "0.2"
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,7 +4,7 @@
 //! - `lrzhs_is_valid_shielded_address`: Validates shielded addresses (Sapling or
 //!   Unified addresses containing shielded receivers)
 
-use std::ffi::{c_char, CStr};
+use std::ffi::{c_char, CStr, CString};
 
 use zcash_address::unified::Container;
 use zcash_address::{ConversionError, TryFromAddress, ZcashAddress};
@@ -144,6 +144,135 @@ pub unsafe extern "C" fn lrzhs_is_valid_shielded_address(
     }
 }
 
+/// Derive a fresh Orchard-only Unified Address from a ZIP-316 Unified Incoming
+/// Viewing Key at the given 88-bit diversifier index.
+///
+/// `uivk` is a NUL-terminated `uivk1…` string. `diversifier_index` points to
+/// exactly 11 bytes. `network_id`: 0 = Testnet, 1 = Mainnet; it must match the
+/// network encoded in the UIVK.
+///
+/// Returns a newly allocated `u1…` C string (free with `lrzhs_string_free`), or
+/// NULL on error (details via `lrzhs_last_error_*`).
+///
+/// # Safety
+/// `uivk` must be a valid NUL-terminated string; `diversifier_index` must point
+/// to at least 11 readable bytes.
+#[no_mangle]
+pub unsafe extern "C" fn lrzhs_derive_orchard_address(
+    uivk: *const c_char,
+    diversifier_index: *const u8,
+    network_id: u32,
+) -> *mut c_char {
+    use orchard::keys::IncomingViewingKey as OrchardIvk;
+    use zcash_address::unified::{
+        Address as UnifiedAddress, Container, Encoding, Ivk, Receiver, Uivk,
+    };
+
+    let res = std::panic::catch_unwind(|| {
+        if uivk.is_null() || diversifier_index.is_null() {
+            ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                "null pointer argument"
+            ));
+            return Err(());
+        }
+        let expected_network = parse_network(network_id)?;
+
+        let uivk_str = match unsafe { CStr::from_ptr(uivk) }.to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                    "Invalid UTF-8 in UIVK: {}",
+                    e
+                ));
+                return Err(());
+            }
+        };
+
+        // Reading exactly 11 bytes makes the try_into total; the arm is defensive.
+        let index_bytes: [u8; 11] =
+            unsafe { std::slice::from_raw_parts(diversifier_index, 11) }
+                .try_into()
+                .map_err(|_| {
+                    ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                        "Invalid diversifier index (expected 11 bytes)"
+                    ));
+                })?;
+
+        let (net, parsed) = Uivk::decode(uivk_str).map_err(|e| {
+            ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                "Failed to decode UIVK: {}",
+                e
+            ));
+        })?;
+
+        if net != expected_network {
+            ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                "UIVK network does not match requested network"
+            ));
+            return Err(());
+        }
+
+        let orchard_ivk_bytes: [u8; 64] = parsed
+            .items()
+            .into_iter()
+            .find_map(|item| match item {
+                Ivk::Orchard(data) => Some(data),
+                _ => None,
+            })
+            .ok_or_else(|| {
+                ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                    "UIVK has no Orchard receiver"
+                ));
+            })?;
+
+        let ivk = OrchardIvk::from_bytes(&orchard_ivk_bytes)
+            .into_option()
+            .ok_or_else(|| {
+                ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                    "Invalid Orchard incoming viewing key bytes"
+                ));
+            })?;
+
+        let receiver = ivk.address_at(index_bytes).to_raw_address_bytes();
+
+        let ua = UnifiedAddress::try_from_items(vec![Receiver::Orchard(receiver)])
+            .map_err(|e| {
+                ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                    "Failed to build unified address: {}",
+                    e
+                ));
+            })?
+            .encode(&net);
+
+        let cstr = CString::new(ua).map_err(|e| {
+            ffi_helpers::error_handling::update_last_error(anyhow::anyhow!(
+                "Invalid address string: {}",
+                e
+            ));
+        })?;
+        Ok(cstr.into_raw())
+    });
+
+    match res {
+        Ok(inner) => unwrap_exc_or(inner, std::ptr::null_mut()),
+        Err(_) => {
+            ffi_helpers::error_handling::update_last_error(anyhow::anyhow!("Panic occurred"));
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Free a string previously returned by an lrzhs function.
+///
+/// # Safety
+/// `s` must be a pointer returned by this library, or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn lrzhs_string_free(s: *mut c_char) {
+    if !s.is_null() {
+        drop(unsafe { CString::from_raw(s) });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,5 +343,72 @@ mod tests {
     #[test]
     fn test_empty_address_returns_false() {
         assert!(!is_valid_shielded_address("", NetworkType::Main));
+    }
+}
+
+#[cfg(test)]
+mod derive_tests {
+    use super::*;
+    use orchard::keys::{FullViewingKey, SpendingKey};
+    use std::ffi::{CStr, CString};
+    use zcash_address::unified::{Address, Encoding, Ivk, Receiver, Uivk};
+    use zcash_protocol::consensus::NetworkType;
+    use zip32::Scope;
+
+    fn mainnet_uivk(seed: u8) -> (String, orchard::keys::IncomingViewingKey) {
+        let sk = SpendingKey::from_bytes([seed; 32]).unwrap();
+        let ivk = FullViewingKey::from(&sk).to_ivk(Scope::External);
+        let uivk = Uivk::try_from_items(vec![Ivk::Orchard(ivk.to_bytes())])
+            .unwrap()
+            .encode(&NetworkType::Main);
+        (uivk, ivk)
+    }
+
+    fn call(uivk: &str, index: [u8; 11], network_id: u32) -> Option<String> {
+        let c = CString::new(uivk).unwrap();
+        let ptr = unsafe { lrzhs_derive_orchard_address(c.as_ptr(), index.as_ptr(), network_id) };
+        if ptr.is_null() {
+            None
+        } else {
+            let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned();
+            unsafe { lrzhs_string_free(ptr) };
+            Some(s)
+        }
+    }
+
+    #[test]
+    fn derives_expected_orchard_only_address() {
+        let (uivk, ivk) = mainnet_uivk(7);
+        let index = [0u8; 11];
+        let expected = Address::try_from_items(vec![Receiver::Orchard(
+            ivk.address_at(index).to_raw_address_bytes(),
+        )])
+        .unwrap()
+        .encode(&NetworkType::Main);
+        assert_eq!(call(&uivk, index, 1), Some(expected));
+    }
+
+    #[test]
+    fn distinct_indices_give_distinct_addresses() {
+        let (uivk, _) = mainnet_uivk(7);
+        assert!(call(&uivk, [0u8; 11], 1) != call(&uivk, [9u8; 11], 1));
+    }
+
+    #[test]
+    fn rejects_invalid_uivk() {
+        assert_eq!(call("not-a-uivk", [0u8; 11], 1), None);
+    }
+
+    #[test]
+    fn rejects_network_mismatch() {
+        let (uivk, _) = mainnet_uivk(7);
+        assert_eq!(call(&uivk, [0u8; 11], 0), None);
+    }
+
+    #[test]
+    fn rejects_null_uivk() {
+        let index = [0u8; 11];
+        let ptr = unsafe { lrzhs_derive_orchard_address(std::ptr::null(), index.as_ptr(), 1) };
+        assert!(ptr.is_null());
     }
 }

--- a/src/Lrzhs.hs
+++ b/src/Lrzhs.hs
@@ -1,10 +1,57 @@
-module Lrzhs (isValidShieldedAddress) where
+module Lrzhs
+  ( isValidShieldedAddress,
+    deriveOrchardAddress,
+    getLastError,
+    DiversifierIndex (..),
+    mkDiversifierIndex,
+  )
+where
 
-import Data.Text (Text, unpack)
+import qualified Data.ByteString.Unsafe as BSU
+import Data.Text (Text, pack, unpack)
 import Foreign.C (CBool (..))
-import Foreign.C.String (withCString)
-import Lrzhs.Ffi (networkId, rs_is_valid_shielded_address)
-import Lrzhs.Types (Network)
+import Foreign.C.String (peekCString, peekCStringLen, withCString)
+import Foreign.C.Types (CChar)
+import Foreign.Marshal.Alloc (allocaBytes)
+import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Lrzhs.Ffi
+  ( networkId,
+    rs_derive_orchard_address,
+    rs_error_message_utf8,
+    rs_is_valid_shielded_address,
+    rs_last_error_length,
+    rs_string_free,
+  )
+import Lrzhs.Types (DiversifierIndex (..), Network, mkDiversifierIndex)
 
 isValidShieldedAddress :: Network -> Text -> IO Bool
-isValidShieldedAddress n t = fmap (\(CBool b) -> b /= 0) $ withCString (unpack t) (\cs -> rs_is_valid_shielded_address cs (networkId n))
+isValidShieldedAddress n t =
+  fmap (\(CBool b) -> b /= 0) $
+    withCString (unpack t) (\cs -> rs_is_valid_shielded_address cs (networkId n))
+
+-- | Fetch the most recent error message recorded by the Rust layer.
+getLastError :: IO Text
+getLastError = do
+  len <- rs_last_error_length
+  if len <= 0
+    then pure (pack "unknown error")
+    else allocaBytes (fromIntegral len) $ \buf -> do
+      written <- rs_error_message_utf8 buf len
+      if written <= 0
+        then pure (pack "unknown error")
+        else pack <$> peekCStringLen (buf, fromIntegral written)
+
+-- | Derive a fresh Orchard-only Unified Address from a ZIP-316 Unified Incoming
+-- Viewing Key at the given diversifier index. Returns 'Left' if the UIVK is
+-- malformed, its network does not match, or it has no Orchard receiver.
+deriveOrchardAddress :: Network -> Text -> DiversifierIndex -> IO (Either Text Text)
+deriveOrchardAddress n uivk (DiversifierIndex idx) =
+  withCString (unpack uivk) $ \uivkPtr ->
+    BSU.unsafeUseAsCStringLen idx $ \(idxPtr, _) -> do
+      resultPtr <- rs_derive_orchard_address uivkPtr (castPtr idxPtr) (networkId n)
+      if resultPtr == nullPtr
+        then Left <$> getLastError
+        else do
+          addr <- pack <$> peekCString resultPtr
+          rs_string_free resultPtr
+          pure (Right addr)

--- a/src/Lrzhs.hs
+++ b/src/Lrzhs.hs
@@ -10,10 +10,9 @@ where
 import qualified Data.ByteString.Unsafe as BSU
 import Data.Text (Text, pack, unpack)
 import Foreign.C (CBool (..))
-import Foreign.C.String (peekCString, peekCStringLen, withCString)
-import Foreign.C.Types (CChar)
+import Foreign.C.String (peekCString, withCString)
 import Foreign.Marshal.Alloc (allocaBytes)
-import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Ptr (castPtr, nullPtr)
 import Lrzhs.Ffi
   ( networkId,
     rs_derive_orchard_address,
@@ -39,7 +38,7 @@ getLastError = do
       written <- rs_error_message_utf8 buf len
       if written <= 0
         then pure (pack "unknown error")
-        else pack <$> peekCStringLen (buf, fromIntegral written)
+        else pack <$> peekCString buf
 
 -- | Derive a fresh Orchard-only Unified Address from a ZIP-316 Unified Incoming
 -- Viewing Key at the given diversifier index. Returns 'Left' if the UIVK is

--- a/src/Lrzhs/Ffi.hs
+++ b/src/Lrzhs/Ffi.hs
@@ -2,16 +2,30 @@
 
 module Lrzhs.Ffi where
 
-import Data.Text (Text, unpack)
-import Data.Word (Word32)
-import Foreign.C (CBool (..), CUInt (..))
+import Data.Word (Word8)
+import Foreign.C (CBool (..), CInt (..), CUInt (..))
 import Foreign.C.String (CString)
-import Foreign.Ptr ()
+import Foreign.C.Types (CChar)
+import Foreign.Ptr (Ptr)
 import Lrzhs.Types (Network (..))
 
-foreign import ccall "lrzhs_is_valid_shielded_address" rs_is_valid_shielded_address :: CString -> CUInt -> IO CBool
+foreign import ccall "lrzhs_is_valid_shielded_address"
+  rs_is_valid_shielded_address :: CString -> CUInt -> IO CBool
+
+foreign import ccall "lrzhs_derive_orchard_address"
+  rs_derive_orchard_address :: CString -> Ptr Word8 -> CUInt -> IO (Ptr CChar)
+
+foreign import ccall "lrzhs_string_free"
+  rs_string_free :: Ptr CChar -> IO ()
+
+foreign import ccall "lrzhs_last_error_length"
+  rs_last_error_length :: IO CInt
+
+foreign import ccall "lrzhs_error_message_utf8"
+  rs_error_message_utf8 :: Ptr CChar -> CInt -> IO CInt
 
 networkId :: Network -> CUInt
 networkId = \case
   Mainnet -> CUInt 1
   Testnet -> CUInt 0
+  Regtest -> CUInt 0

--- a/src/Lrzhs/Types.hs
+++ b/src/Lrzhs/Types.hs
@@ -1,6 +1,25 @@
-module Lrzhs.Types (Network (..)) where
+module Lrzhs.Types
+  ( Network (..),
+    DiversifierIndex (..),
+    mkDiversifierIndex,
+  )
+where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 
 data Network
   = Mainnet
   | Testnet
   | Regtest
+
+-- | An 88-bit (11-byte) Orchard diversifier index. Construct only via
+-- 'mkDiversifierIndex', which enforces the length invariant.
+newtype DiversifierIndex = DiversifierIndex {diversifierIndexBytes :: ByteString}
+  deriving (Eq, Show)
+
+-- | Build a 'DiversifierIndex' from exactly 11 bytes; 'Nothing' otherwise.
+mkDiversifierIndex :: ByteString -> Maybe DiversifierIndex
+mkDiversifierIndex bs
+  | BS.length bs == 11 = Just (DiversifierIndex bs)
+  | otherwise = Nothing

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import qualified Data.ByteString as BS
 import Data.Either (isLeft)
 import Data.Maybe (fromJust)
 import Data.Text (Text)
+import qualified Data.Text as T
 import Lrzhs (deriveOrchardAddress, isValidShieldedAddress, mkDiversifierIndex)
 import Lrzhs.Types (Network (..))
 import System.Exit (exitFailure, exitSuccess)
@@ -54,7 +55,11 @@ main = do
         test
           "derive rejects a network mismatch"
           True
-          (isLeft <$> deriveOrchardAddress Testnet testUivk zeroIdx)
+          (isLeft <$> deriveOrchardAddress Testnet testUivk zeroIdx),
+        test
+          "derive error message is NUL-free"
+          True
+          (either (T.all (/= '\NUL')) (const False) <$> deriveOrchardAddress Mainnet "not-a-uivk" zeroIdx)
       ]
   if and results then exitSuccess else exitFailure
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,38 +1,76 @@
 module Main where
 
-import System.Exit (exitFailure, exitSuccess)
-import Lrzhs (isValidShieldedAddress)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import Lrzhs (deriveOrchardAddress, isValidShieldedAddress, mkDiversifierIndex)
 import Lrzhs.Types (Network (..))
+import System.Exit (exitFailure, exitSuccess)
 
 main :: IO ()
 main = do
-  results <- sequence
-    [ test "valid Sapling address"
-        True
-        (isValidShieldedAddress Mainnet "zs1mrhc9y7jdh5r9ece8u5khgvj9kg0zgkxzdduyv0whkg7lkcrkx5xqem3e48avjq9wn2rukydkwn")
-    , test "valid unified address (short)"
-        True
-        (isValidShieldedAddress Mainnet "u1l8xunezsvhq8fgzfl7404m450nwnd76zshscn6nfys7vyz2ywyh4cc5daaq0c7q2su5lqfh23sp7fkf3kt27ve5948mzpfdvckzaect2jtte308mkwlycj2u0eac077wu70vqcetkxf")
-    , test "valid unified address (long)"
-        True
-        (isValidShieldedAddress Mainnet "u1pg2aaph7jp8rpf6yhsza25722sg5fcn3vaca6ze27hqjw7jvvhhuxkpcg0ge9xh6drsgdkda8qjq5chpehkcpxf87rnjryjqwymdheptpvnljqqrjqzjwkc2ma6hcq666kgwfytxwac8eyex6ndgr6ezte66706e3vaqrd25dzvzkc69kw0jgywtd0cmq52q5lkw6uh7hyvzjse8ksx")
-    , test "invalid address (empty)"
-        False
-        (isValidShieldedAddress Mainnet "")
-    , test "invalid address (garbage)"
-        False
-        (isValidShieldedAddress Mainnet "notanaddress")
-    , test "invalid address (transparent)"
-        False
-        (isValidShieldedAddress Mainnet "t1Rv4exT7bqhZqi2j7xz8bUHDMxwosrjADU")
-    , test "valid mainnet address on testnet"
-        False
-        (isValidShieldedAddress Testnet "zs1mrhc9y7jdh5r9ece8u5khgvj9kg0zgkxzdduyv0whkg7lkcrkx5xqem3e48avjq9wn2rukydkwn")
-    ]
+  let zeroIdx = fromJust (mkDiversifierIndex (BS.replicate 11 0))
+      testUivk = "uivk1ewu2n4n4xgwxvem5krz36flunule40kyss82myn583hj9ypsrmt34yw3t5h6utkcx45w3tcharxck5fzurycymxp408wxh7f7u2snqdekm8d9au580fvm7yj9y3qsw7d4l9qsmsz98" :: Text
+      expectedUa = "u1u4zdvtcrjt4cnffw3shrx440754g0mhr4a7fenck686tfr6rdqy9wu5v39ydpgm4ut37qnlh9kpw9fsp8wcwyu2y2r5stjhj0qwfnmrq" :: Text
+  results <-
+    sequence
+      [ test
+          "valid Sapling address"
+          True
+          (isValidShieldedAddress Mainnet "zs1mrhc9y7jdh5r9ece8u5khgvj9kg0zgkxzdduyv0whkg7lkcrkx5xqem3e48avjq9wn2rukydkwn"),
+        test
+          "valid unified address (short)"
+          True
+          (isValidShieldedAddress Mainnet "u1l8xunezsvhq8fgzfl7404m450nwnd76zshscn6nfys7vyz2ywyh4cc5daaq0c7q2su5lqfh23sp7fkf3kt27ve5948mzpfdvckzaect2jtte308mkwlycj2u0eac077wu70vqcetkxf"),
+        test
+          "valid unified address (long)"
+          True
+          (isValidShieldedAddress Mainnet "u1pg2aaph7jp8rpf6yhsza25722sg5fcn3vaca6ze27hqjw7jvvhhuxkpcg0ge9xh6drsgdkda8qjq5chpehkcpxf87rnjryjqwymdheptpvnljqqrjqzjwkc2ma6hcq666kgwfytxwac8eyex6ndgr6ezte66706e3vaqrd25dzvzkc69kw0jgywtd0cmq52q5lkw6uh7hyvzjse8ksx"),
+        test
+          "invalid address (empty)"
+          False
+          (isValidShieldedAddress Mainnet ""),
+        test
+          "invalid address (garbage)"
+          False
+          (isValidShieldedAddress Mainnet "notanaddress"),
+        test
+          "invalid address (transparent)"
+          False
+          (isValidShieldedAddress Mainnet "t1Rv4exT7bqhZqi2j7xz8bUHDMxwosrjADU"),
+        test
+          "valid mainnet address on testnet"
+          False
+          (isValidShieldedAddress Testnet "zs1mrhc9y7jdh5r9ece8u5khgvj9kg0zgkxzdduyv0whkg7lkcrkx5xqem3e48avjq9wn2rukydkwn"),
+        testEq
+          "derive Orchard-only address at index 0 (mainnet)"
+          (Right expectedUa)
+          (deriveOrchardAddress Mainnet testUivk zeroIdx),
+        test
+          "derive rejects a malformed UIVK"
+          True
+          (isLeft <$> deriveOrchardAddress Mainnet "not-a-uivk" zeroIdx),
+        test
+          "derive rejects a network mismatch"
+          True
+          (isLeft <$> deriveOrchardAddress Testnet testUivk zeroIdx)
+      ]
   if and results then exitSuccess else exitFailure
 
 test :: String -> Bool -> IO Bool -> IO Bool
 test name expected action = do
+  result <- action
+  if result == expected
+    then do
+      putStrLn $ "  PASS: " ++ name
+      pure True
+    else do
+      putStrLn $ "  FAIL: " ++ name ++ " (expected " ++ show expected ++ ", got " ++ show result ++ ")"
+      pure False
+
+testEq :: (Eq a, Show a) => String -> a -> IO a -> IO Bool
+testEq name expected action = do
   result <- action
   if result == expected
     then do


### PR DESCRIPTION
## Summary
- Add `lrzhs_derive_orchard_address` (Rust FFI) + `lrzhs_string_free`: derive a fresh **Orchard-only** Unified Address from a ZIP-316 Unified Incoming Viewing Key at a caller-supplied 88-bit diversifier index. Pure/stateless — no wallet DB, no chain sync.
- Add Haskell wrappers: `deriveOrchardAddress :: Network -> Text -> DiversifierIndex -> IO (Either Text Text)`, a length-checked `DiversifierIndex` smart constructor, and an exported `getLastError`.
- New deps: `orchard 0.14`, `zip32 0.2` (orchard 0.11–0.13 are yanked on crates.io; 0.14 has the same API). Version bumped to 0.2.0.0.

## Test Plan
- [x] Rust: `cargo test --lib` — 12 pass (round-trip vs. independent orchard derivation, distinct-index, invalid-UIVK, network-mismatch, null-pointer guard).
- [x] Haskell: `cabal test` — 11 pass (happy path vs. a fixed mainnet vector, malformed UIVK, network mismatch, NUL-free error text).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
